### PR TITLE
Resolution for IOMAD Issue #219

### DIFF
--- a/blocks/iomad_company_admin/lib/course_selectors.php
+++ b/blocks/iomad_company_admin/lib/course_selectors.php
@@ -26,6 +26,9 @@ abstract class company_course_selector_base extends course_selector_base {
     protected $companyid;
     protected $hasenrollments = false;
 
+    //overridden to include the sortorder field
+    protected $requiredfields = array('id', 'fullname', 'sortorder');
+
     public function __construct($name, $options) {
         $this->companyid  = $options['companyid'];
         parent::__construct($name, $options);
@@ -450,9 +453,6 @@ class potential_subdepartment_course_selector extends company_course_selector_ba
         $this->departmentid = $options['departmentid'];
         $this->showopenshared = $options['showopenshared'];
         $this->license = $options['license'];
-
-        // Must select sortorder if we are going to ORDER BY on it.
-        $options['extrafields'][] = 'sortorder';
 
         parent::__construct($name, $options);
     }

--- a/local/course_selector/lib.php
+++ b/local/course_selector/lib.php
@@ -60,6 +60,9 @@ abstract class course_selector_base {
     protected $file = null;
     protected $selectedid = 0;
 
+    //defines the base required fields for this selector.
+    protected $requiredfields = array('id', 'fullname');
+
     /**  @var boolean Used to ensure we only output the search options for one course selector on
      * each page. */
     private static $searchoptionsoutput = false;
@@ -419,7 +422,7 @@ abstract class course_selector_base {
      */
     protected function required_fields_sql($u) {
         // Raw list of fields.
-        $fields = array('id', 'fullname');
+        $fields = (array) $this->requiredfields;
         $fields = array_merge($fields, $this->extrafields);
 
         // Prepend the table alias.


### PR DESCRIPTION
Resolution for issue #219 
Sortorder is no longer added as an extrafield for company_course_selector_base but is instead included a new protected attribute $requiredfields in local/course_selector/lib.php
