### PR TITLE
Select only valid license by default

### DIFF
--- a/blocks/iomad_company_admin/company_license_users_form.php
+++ b/blocks/iomad_company_admin/company_license_users_form.php
@@ -371,6 +371,12 @@ if (iomad::has_capability('block/iomad_company_admin:unallocate_licenses', conte
     }
 }
 
+// If the user has not selected a license, and they only have one valid license, select it for them.
+if (empty($licenseid) && count($licenselist) === 1) {
+       reset($licenselist);
+       $licenseid = key($licenselist);
+}
+
 $usersform = new company_license_users_form($PAGE->url, $context, $companyid, $licenseid, $userhierarchylevel, $selectedcourses);
 
 $blockpage->display_header();


### PR DESCRIPTION
If the company only has one license, select it by default instead of forcing them to select it manually
