### PR TITLE
Fix db error in local/report_users and block/iomad_company_admin

### DIFF
--- a/blocks/iomad_company_admin/editusers.php
+++ b/blocks/iomad_company_admin/editusers.php
@@ -442,7 +442,7 @@ if (iomad::has_capability('block/iomad_company_admin:editallusers', $systemconte
     // Make sure we dont display site admins.
     // Set default search to something which cant happen.
     $sqlsearch = "id!='-1'";
-    $siteadmins = explode(" ", $CFG->siteadmins);
+    $siteadmins = explode(",", $CFG->siteadmins);
     foreach ($siteadmins as $siteadmin) {
         $sqlsearch .= " AND id!='$siteadmin'";
     }

--- a/local/report_users/index.php
+++ b/local/report_users/index.php
@@ -260,7 +260,7 @@ $dbsort = "";
         // Make sure we dont display site admins.
         // Set default search to something which cant happen.
         $sqlsearch = "id!='-1'";
-        $siteadmins = explode(" ", $CFG->siteadmins);
+        $siteadmins = explode(",", $CFG->siteadmins);
         foreach ($siteadmins as $siteadmin) {
             $sqlsearch .= " AND id!='$siteadmin'";
         }


### PR DESCRIPTION
Adding more than one site admin breaks these plugins with a message "Error reading from database" .
