### PR TITLE
IOMAD: Fix typo in db call that broke updating users

### DIFF
--- a/local/iomad/lib/company.php
+++ b/local/iomad/lib/company.php
@@ -348,7 +348,7 @@ class company {
      **/
     public static function get_company_byuserid($userid) {
         global $DB;
-        $companies = $DB->get_record_sql("SELECT c.* FROM {company_users} cu
+        $companies = $DB->get_records_sql("SELECT c.* FROM {company_users} cu
                                           INNER JOIN {company} c ON cu.companyid = c.id
                                           WHERE cu.userid = :userid
                                           ORDER BY cu.id",


### PR DESCRIPTION
The code used get_record_sql but then did an array_shift on the result which will be an object not an array. I've changed the code to use get_records_sql which seems to be the correct given the parameters you are passing in.