### PR TITLE
ISSUE 1081: Fixes manual instance cache for IOMAD enrolments

### DIFF
--- a/local/iomad/lib/user.php
+++ b/local/iomad/lib/user.php
@@ -302,8 +302,8 @@ class company_user {
             }
 
             if (!isset($manualcache[$courseid])) {
-                if ($instances = enrol_get_instances($courseid, false)) {
-                    $manualcache[$courseid] = reset($instances);
+                if ($instance = $DB->get_record('enrol', array('courseid'=>$courseid, 'enrol'=>'manual'))) {
+                    $manualcache[$courseid] = $instance;
                 } else {
                     $manualcache[$courseid] = false;
                 }


### PR DESCRIPTION
I opted for this route because the original code was grabbing all instances, enabled or not which was just a simple DB->get_records. Instead, I changed it to pull the specific instance matching the manual enrol instance in the course.
