### PR TITLE
IOMAD: Delete company and lp entries before course. fixes #1043

### DIFF
--- a/local/iomad/classes/observer.php
+++ b/local/iomad/classes/observer.php
@@ -184,17 +184,6 @@ class local_iomad_observer {
     }
 
     /**
-     * Triggered via course_deleted event.
-     *
-     * @param \core\event\course_deleted $event
-     * @return bool true on success.
-     */
-    public static function course_deleted($event) {
-        company::course_deleted($event);
-        return true;
-    }
-
-    /**
      * Triggered via block_iomad_company_admin::user_course_expired event.
      *
      * @param \block_iomad_company_admin\event\user_course_expired $event

--- a/local/iomad/db/events.php
+++ b/local/iomad/db/events.php
@@ -71,13 +71,6 @@ $observers = array(
     ),
 
     array(
-        'eventname'   => '\core\event\course_deleted',
-        'callback'    => 'local_iomad_observer::course_deleted',
-        'includefile' => '/local/iomad/classes/observer.php',
-        'internal'    => false,
-    ),
-
-    array(
         'eventname'   => '\core\event\user_deleted',
         'callback'    => 'local_iomad_observer::user_deleted',
         'includefile' => '/local/iomad/classes/observer.php',

--- a/local/iomad/db/install.xml
+++ b/local/iomad/db/install.xml
@@ -108,6 +108,8 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="licenseid" TYPE="foreign" FIELDS="licenseid" REFTABLE="companylicense" REFFIELDS="id"/>
+        <KEY NAME="licensecourseid" TYPE="foreign" FIELDS="licensecourseid" REFTABLE="course" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
     <TABLE NAME="companylicense_courses" COMMENT="for keeping track of license course allocations">

--- a/local/iomad/db/upgrade.php
+++ b/local/iomad/db/upgrade.php
@@ -1918,7 +1918,7 @@ function xmldb_local_iomad_upgrade($oldversion) {
 
             // Find broken licenses and delete missing courses.
             $licenses = $DB->get_fieldset_select('companylicense_courses', 'licenseid', "NOT courseid $sql", $params);
-            $DB->delete_records_select('companylicense_courses', "NOT licenseid $sql", $params);
+            $DB->delete_records_select('companylicense_courses', "NOT courseid $sql", $params);
 
             // Delete any licenses that are left empty.
             $sql = 'SELECT l.id

--- a/local/iomad/lang/en/local_iomad.php
+++ b/local/iomad/lang/en/local_iomad.php
@@ -50,6 +50,7 @@ $string['privacy:metadata:companylicense_users:licensecourseid'] = 'Company lice
 $string['privacy:metadata:companylicense_users:issuedate'] = 'Company license user issue date';
 $string['privacy:metadata:companylicense_users:groupid'] = 'Company license users group id';
 $string['privacy:metadata:companylicense_users'] = 'Company license users';
+$string['removelicenses'] = 'Deleted - Company course records and licenses';
 $string['setupiomad'] = 'Start setting up iomad';
 $string['show_suspended_users'] = 'Show suspended users?';
 $string['userfilter'] = 'Filter results';

--- a/local/iomad/lib.php
+++ b/local/iomad/lib.php
@@ -1,0 +1,66 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * This file contains the lib functions for local_iomad
+ *
+ * @package local_iomad
+ * @copyright  2019 Daniel Thies <dethies@gmail.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Hook called by delete_course to remove iomad table references before course is deleted
+ *
+ * @param object course record
+ */
+function local_iomad_pre_course_delete($course) {
+    global $DB, $OUTPUT;
+
+    // Clear everything from the iomad_courses table.
+    $DB->delete_records('iomad_courses', array('courseid' => $course->id));
+
+    // Remove the course from company allocation tables.
+    $DB->delete_records('company_course', array('courseid' => $course->id));
+
+    // Remove the course from company created course tables.
+    $DB->delete_records('company_created_courses', array('courseid' => $course->id));
+
+    // Remove the course from company shared courses tables.
+    $DB->delete_records('company_shared_courses', array('courseid' => $course->id));
+
+    // Deal with licenses allocations.
+    $DB->delete_records('companylicense_users', array('licensecourseid' => $course->id));
+
+    $courselicenses = $DB->get_records('companylicense_courses', array('courseid' => $course->id));
+
+    foreach ($courselicenses as $courselicense) {
+        // Delete the course from the license.
+        $DB->delete_records('companylicense_courses', array('id' => $courselicense->id));
+        // Does the license have any courses left?
+        if ($DB->get_records('companylicense_courses', array('licenseid' => $courselicense->licenseid))) {
+            company::update_license_usage($courselicense->licenseid);
+        } else {
+            // Delete the license.  It no longer is valid.
+            $DB->delete_records('companylicense', array('id' => $courselicense->licenseid));
+        }
+    }
+    echo $OUTPUT->notification(get_string('removelicenses', 'local_iomad'), 'notifysuccess');
+
+    return true;
+}

--- a/local/iomad/lib/company.php
+++ b/local/iomad/lib/company.php
@@ -2879,45 +2879,6 @@ class company {
     }
 
     /**
-     * Triggered via course_deleted event.
-     *
-     * @param \core\event\course_deleted $event
-     * @return bool true on success.
-     */
-    public static function course_deleted(\core\event\course_deleted $event) {
-        global $DB;
-
-        // Clear everything from the iomad_courses table.
-        $DB->delete_records('iomad_courses', array('courseid' => $event->courseid));
-
-        // Remove the course from company allocation tables.
-        $DB->delete_records('company_course', array('courseid' => $event->courseid));
-
-        // Remove the course from company created course tables.
-        $DB->delete_records('company_created_courses', array('courseid' => $event->courseid));
-
-        // Remove the course from company shared courses tables.
-        $DB->delete_records('company_shared_courses', array('courseid' => $event->courseid));
-
-        // Deal with licenses allocations.
-        $DB->delete_records('companylicense_users', array('licensecourseid' => $event->courseid));
-        $courselicenses = $DB->get_records('companylicense_courses', array('courseid' => $event->courseid));
-        foreach ($courselicenses as $courselicense) {
-            // Delete the course from the license.
-            $DB->delete_record('companylicense_courses', array('id' => $courselicense->id));
-            // Does the license have any courses left?
-            if ($DB->get_records('companylicense_courses', array('licensid' => $courselicense->licenseid))) {
-                self::update_license_usage($courselicense->licenseid);
-            } else {
-                // Delete the license.  It no longer is valid.
-                $DB->delete_records('companylicense', array('id' => $courselicense->licenseid));
-            }
-        }
-
-        return true;
-    }
-
-    /**
      * Triggered via course_completed event.
      *
      * @param \core\event\course_completed $event

--- a/local/iomad/version.php
+++ b/local/iomad/version.php
@@ -15,5 +15,5 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 $plugin->component  = 'local_iomad';
-$plugin->version  = 2019030100;   // The (date) version of this plugin.
+$plugin->version  = 2019030101;   // The (date) version of this plugin.
 $plugin->requires = 2016052301;   // Requires this Moodle version.

--- a/local/iomad_learningpath/db/install.xml
+++ b/local/iomad_learningpath/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="local/iomad_learningpath/db" VERSION="20180430" COMMENT="XMLDB file for Moodle local/iomad_learningpath"
+<XMLDB PATH="local/iomad_learningpath/db" VERSION="20190208" COMMENT="XMLDB file for Moodle local/iomad_learningpath"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -32,6 +32,8 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="course" TYPE="foreign" FIELDS="course" REFTABLE="course" REFFIELDS="id"/>
+        <KEY NAME="group" TYPE="foreign" FIELDS="groupid" REFTABLE="iomad_learningpathgroup" REFFIELDS="id"/>
       </KEYS>
       <INDEXES>
         <INDEX NAME="ix_pa" UNIQUE="false" FIELDS="path"/>

--- a/local/iomad_learningpath/lang/en/local_iomad_learningpath.php
+++ b/local/iomad_learningpath/lang/en/local_iomad_learningpath.php
@@ -74,6 +74,7 @@ $string['picture_help'] = 'Picture associated with Learning Path';
 $string['pluginname'] = 'Iomad learning paths';
 $string['prospectivecourses'] = 'Prospective courses';
 $string['prospectivestudents'] = 'Prospective students';
+$string['removepath'] = 'Deleted - Learning path information';
 $string['selectedstudents'] = 'Selected student assignments';
 $string['showcoursedescription'] = 'Show course description';
 $string['showcoursedescription_desc'] = 'Show full course description in learning plans';

--- a/local/iomad_learningpath/lib.php
+++ b/local/iomad_learningpath/lib.php
@@ -66,3 +66,18 @@ function local_iomad_learningpath_pluginfile($course,
 
 }
 
+/**
+ * Hook called by delete_course to remove course from path before course is deleted
+ *
+ * @param object course record
+ */
+function local_iomad_learningpath_pre_course_delete($course) {
+    global $DB, $OUTPUT;
+
+    // Clear references from the iomad_learningpathcourse table.
+    $DB->delete_records('iomad_learningpathcourse', array('course' => $course->id));
+
+    echo $OUTPUT->notification(get_string('removepath', 'local_iomad_learningpath'), 'notifysuccess');
+
+    return true;
+}

--- a/local/iomad_learningpath/version.php
+++ b/local/iomad_learningpath/version.php
@@ -24,6 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2018043000;   // The (date) version of this plugin.
+$plugin->version  = 2018043001;   // The (date) version of this plugin.
 $plugin->requires = 2017051500;   // Requires this Moodle version. (3.3)
 $plugin->component = 'local_iomad_learningpath';


### PR DESCRIPTION
This patch deletes relevant IOMAD table entries before the relevant course table entry. This makes it possible to add keys to the IOMAD references to the course table id to accelerate license and learning path look ups.