### PR TITLE
block_iomad_company_admin: Add missing global so admins can select su…

### DIFF
--- a/blocks/iomad_company_admin/block_iomad_company_admin.php
+++ b/blocks/iomad_company_admin/block_iomad_company_admin.php
@@ -79,7 +79,7 @@ class block_iomad_company_admin extends block_base {
      * Check company status when accessing this block
      */
     private function check_company_status() {
-        global $SESSION, $DB;
+        global $SESSION, $DB, $USER;
 
         $systemcontext = context_system::instance();
 


### PR DESCRIPTION
$DB->get_record('company_users', array('managertype' => 1, 'companyid' => $company, 'userid' => $USER->id)) was failing as the $USER global had not been declared.