### PR TITLE
local_email: Make company name a substitution not replacement

### DIFF
--- a/local/email/lib/api.php
+++ b/local/email/lib/api.php
@@ -454,11 +454,7 @@ class EmailTemplate {
                 $supportuser->customheaders['From'] = $template->emailfromother;
             }
             if (!empty($template->emailfromothername)) {
-                if ($template->emailfromothername == "{Company_Name}") {
-                    $supportuser->firstname = $company->get_name();
-                } else {
-                    $supportuser->firstname = $template->emailfromothername;
-                }
+                $supportuser->firstname = str_replace('{Company_Name}', $company->get_name(), $template->emailfromothername);
             }
             if (!empty($template->emailfrom)) {
                 $fromuser = self::get_user($template->emailfrom);


### PR DESCRIPTION
Company_Name was only getting swapped out if it was an exact match, you couldn't substitute it e.g. '{Company_Name} via TechProvider'