### PR TITLE
Update company_edit_form.php to allow for iomadboost as a valid iomad parent theme to show company appearence options

### DIFF
--- a/blocks/iomad_company_admin/classes/forms/company_edit_form.php
+++ b/blocks/iomad_company_admin/classes/forms/company_edit_form.php
@@ -338,8 +338,9 @@ class company_edit_form extends \company_moodleform {
         $ischild = false;
         try {
             $theme = \theme_config::load($companytheme);
+            $iomadthemes = array('iomad', 'iomadboost', 'iomadbootstrap');
             foreach ($theme->parents as $parentstheme) {
-                if($parentstheme == 'iomad' || $parentstheme == 'bootstrap' ){
+                if(in_array($parentstheme, $iomadthemes)){
                     $ischild = true;
                     break;
                 }


### PR DESCRIPTION
Include iomadboost and iomadbootstrap as valid parent themes so that the iomad Appearence options are shown (eg. companylogo, customcss) - also remove bootstrap, as it is not a valid iomad theme?