### PR TITLE
fix: use more compatible sql querries

### DIFF
--- a/local/iomad/db/install.php
+++ b/local/iomad/db/install.php
@@ -33,6 +33,6 @@ function xmldb_local_iomad_install() {
     set_config('defaultblocks_weeks', $defblocks);
 
     // Change the default settings for extended username chars to be true.
-    $DB->execute("update {config} set value=1 where name='extendedusernamechars'");
+    $DB->execute("update {config} set value='1' where name='extendedusernamechars'");
 
 }

--- a/local/report_completion/index.php
+++ b/local/report_completion/index.php
@@ -354,7 +354,7 @@ if (empty($courseid)) {
     $fromsql = "{local_iomad_track}";
     $sqlparams = array('companyid' => $companyid) + $searchparams;
 
-    $wheresql = "companyid = :companyid $coursesearchsql group by courseid";
+    $wheresql = "companyid = :companyid $coursesearchsql group by courseid, coursename, companyid";
 
     // Set up the headers for the table.
     $courseheaders = array(get_string('coursename', 'local_report_completion'),

--- a/mod/iomadcertificate/locallib.php
+++ b/mod/iomadcertificate/locallib.php
@@ -461,7 +461,7 @@ function iomadcertificate_get_issues($iomadcertificateid, $sort="ci.timecreated 
 
     // The picture fields also include the name fields for the user.
     $picturefields = user_picture::fields('u', get_extra_user_fields($context));
-    $users = $DB->get_records_sql("SELECT concat(u.id, concat('-', ci.code)) AS indexcode, $picturefields, u.idnumber, ci.code, ci.timecreated
+    $users = $DB->get_records_sql("SELECT ". $DB->sql_concat("'u.id'", $DB->sql_concat("'-'", 'ci.code')) . " AS indexcode, $picturefields, u.idnumber, ci.code, ci.timecreated
                                      FROM {user} u
                                INNER JOIN {iomadcertificate_issues} ci
                                        ON u.id = ci.userid


### PR DESCRIPTION
These changes enable database compatibility for other database providers than postgresql. We are using a currently not-upstreamed cockroachdb database provider, but these likely help with others as well.