### PR TITLE
enable completion tracking for a user in multiple companies

### DIFF
--- a/blocks/mycourses/locallib.php
+++ b/blocks/mycourses/locallib.php
@@ -41,8 +41,9 @@ function mycourses_get_my_completion($datefrom = 0) {
                                        JOIN {course} c ON (c.id = cc.courseid)
                                        WHERE cc.userid = :userid
                                        AND c.visible = 1
-                                       AND cc.timecompleted IS NOT NULL",
-                                       array('userid' => $USER->id));
+                                       AND cc.timecompleted IS NOT NULL
+                                       AND cc.companyid = :companyid",
+                                       array('userid' => $USER->id, "companyid" => $companyid));
     $myinprogress = $DB->get_records_sql("SELECT cc.id, cc.userid, cc.courseid as courseid, c.fullname as coursefullname, c.summary as coursesummary
                                           FROM {local_iomad_track} cc
                                           JOIN {course} c ON (c.id = cc.courseid)
@@ -51,8 +52,9 @@ function mycourses_get_my_completion($datefrom = 0) {
                                           WHERE cc.userid = :userid
                                           AND c.visible = 1
                                           AND cc.timecompleted IS NULL
-                                          AND ue.timestart != 0",
-                                          array('userid' => $USER->id));
+                                          AND ue.timestart != 0
+                                          AND cc.companyid = :companyid",
+                                          array('userid' => $USER->id, "companyid" => $companyid));
 
     // We dont care about these.  If you have enrolled then you are started.
     $mynotstartedenrolled = array();

--- a/local/report_completion/lib.php
+++ b/local/report_completion/lib.php
@@ -91,7 +91,7 @@ class comprep{
     public static function getcompanyusers( $companyid ) {
         global $DB;
 
-        if (! $dataids = $DB->get_records('company_users', array('company_id' => $companyid))) {
+        if (! $dataids = $DB->get_records('company_users', array('companyid' => $companyid))) {
             return array();
         }
 


### PR DESCRIPTION
This PR enables course tracking for a user in multiple companies. 

For our use case we automatically add users to a company when they are created through some custom scripts. There is a possibility for our clients to have workers that are part of more than one company, so we need to support them in meeting those audit requirements.

This adds a function which will get all companies a userid is part of, and then processes those events for each company on enrolment and completion events
