### PR TITLE
lib.php user informed if certificate has been generated

### DIFF
--- a/admin/tool/redocerts/lib.php
+++ b/admin/tool/redocerts/lib.php
@@ -77,7 +77,14 @@ function do_redocerts($user = 0, $course = 0, $company = 0, $idnumber = 0, $from
         echo "<br>clearing id $track->id - $count out of $total </br>";
         local_iomad_track_delete_entry($track->id);
         echo "</br>Recreating Certificate</br>";
-        xmldb_local_iomad_track_record_certificates($track->courseid, $track->userid, $track->id);
+        
+        // Inform the user if the certificate has been generated or skipped
+        if(xmldb_local_iomad_track_record_certificates($track->courseid, $track->userid, $track->id)){
+            echo '<p>Certificate generated successfully.</p>';   
+        } else {
+            echo '<p>Certificate generation skipped - user has not completed the course.</p>';
+        }
+        // REMOVABLE NOTICE: I haven't used any the "Moodle way" of writing HTML, of course feel free to add that if you want. :)
     
         $count++;
     }


### PR DESCRIPTION
Previously, the function xmldb_local_iomad_track_record_certificates would run, and nothing else would happen. However, if it does not generate a certificate then the user is none the wiser. This fix is an addition to some code that has been modified in the declaration of the xmldb_local_iomad_track_record_certificates function whereby it will return true or false depending on the outcome of the certificate generation. For the certificate to generate, the user will need to have a timecompleted value in the local_iomad_track table. If they do not, the function will return false and the user will be informed.

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
