### PR TITLE
fix: sql queries shouldn't use || for boolean operations

### DIFF
--- a/local/report_completion/index.php
+++ b/local/report_completion/index.php
@@ -483,7 +483,7 @@ if (empty($courseid)) {
 
     // Just valid courses?
     if ($validonly) {
-        $validsql = " AND (lit.timeexpires > :runtime || (lit.timecompleted IS NULL) || (lit.timecompleted > 0 AND lit.timeexpires IS NULL))";
+        $validsql = " AND (lit.timeexpires > :runtime or (lit.timecompleted IS NULL) or (lit.timecompleted > 0 AND lit.timeexpires IS NULL))";
         $sqlparams['runtime'] = time();
     } else {
         $validsql = "";

--- a/local/report_completion/report_course_completion_course_table.php
+++ b/local/report_completion/report_course_completion_course_table.php
@@ -256,12 +256,11 @@ class local_report_course_completion_course_table extends table_sql {
 
     // Just valid courses?
     if ($params['validonly']) {
-        $validcompletedsql = " AND (lit.timeexpires > :runtime || (lit.timecompleted > 0 AND lit.timeexpires IS NULL))";
+        $validcompletedsql = " AND (lit.timeexpires > :runtime or (lit.timecompleted > 0 AND lit.timeexpires IS NULL))";
         $sqlparams['runtime'] = time();
     } else {
         $validcompletedsql = "";
     }
-
 
         // Count the completed users.
         $completed = $DB->count_records_sql("SELECT COUNT(lit.id)

--- a/local/report_users/userdisplay.php
+++ b/local/report_users/userdisplay.php
@@ -188,7 +188,7 @@ $sqlparams = array('userid' => $userid, 'companyid' => $companyid);
 
 // Just valid courses?
 if ($validonly) {
-    $validsql = " AND (lit.timeexpires > :runtime || (lit.timecompleted IS NULL) || (lit.timecompleted > 0 AND lit.timeexpires IS NULL))";
+    $validsql = " AND (lit.timeexpires > :runtime or (lit.timecompleted IS NULL) or (lit.timecompleted > 0 AND lit.timeexpires IS NULL))";
     $sqlparams['runtime'] = time();
 } else {
     $validsql = "";


### PR DESCRIPTION
I was looking into documenting auditing features and I found the "expired course results" toggle was throwing sql errors. I believe this fix is inline with the intention of these sql queries.

Semi-related, I'm not certain that the way this toggle works is conducive for completing an audit ensuring that all users are trained. It seems to me that once a user completes training, after their training expires they will simply disappear from the dashboard with the "expired course result" off instead of showing up as needing training. Is this a query error or a setup issue on my part?