### PR TITLE
IOMAD: Fix #1649 error in bulk upload user

### DIFF
--- a/local/iomad/lib/company.php
+++ b/local/iomad/lib/company.php
@@ -2429,8 +2429,8 @@ class company {
             // Get the list of departments at and below the user assignment.
             $userhierarchylevels = $company->get_userlevel($USER);
             $subhierarchytree = array();
-            foreach ($userhierarchylevels as $userhierachylevl) {
-                $subhierarchies = $subhierarchies + self::get_all_subdepartments($userhierarchylevel->id);
+            foreach ($userhierarchylevels as $userhierarchylevel) {
+                $subhierarchytree = $subhierarchytree + self::get_all_subdepartments($userhierarchylevel->id);
             }
             if (isset($subhierarchytree[$departmentid])) {
                 // Current department is a child of the users assignment.


### PR DESCRIPTION
This error occurred because the typo of the variables lead to a NULL + array.