### PR TITLE
IOMAD: Fix typo of output in course_group_users_form.php

### DIFF
--- a/blocks/iomad_company_admin/classes/forms/course_group_users_form.php
+++ b/blocks/iomad_company_admin/classes/forms/course_group_users_form.php
@@ -172,7 +172,7 @@ class course_group_users_form extends moodleform {
 
             $mform->addElement('html', '
                       <input name="remove" id="remove" type="submit" value="' .
-                       get_string('remove') . '&nbsp;' . $ouput->rarrow() .
+                       get_string('remove') . '&nbsp;' . $output->rarrow() .
                        '" title="'.get_string('remove') .'" /></br>');
         }
 


### PR DESCRIPTION
Fixed the error when Company Manager is assigning students to groups because of the typo of `$ouput` (should be `$output`)