### PR TITLE
Fix variable typo in local_email

### DIFF
--- a/local/email/lib.php
+++ b/local/email/lib.php
@@ -45,7 +45,7 @@ function email_cron() {
             $company = new company($email->companyid);
             $managertype = 0;
             if (strpos($email->templatename, 'manager')) {
-                $manapegertype = 1;
+                $managertype = 1;
             }
             if (strpos($email->templatename, 'supervisor')) {
                 $managertype = 2;


### PR DESCRIPTION
While looking for something else in the IOMAD source code, I stumbled upon a variable typo in local_email which may result in the fact that emails are not sent out to managers.

I submit this PR just to fix this typo, but I would like to ask you to review it thoroughly and assess the implications yourself.

Thanks,
Alex