### PR TITLE
IOMAD: Fix user assignment to a company

### DIFF
--- a/blocks/iomad_company_admin/externallib.php
+++ b/blocks/iomad_company_admin/externallib.php
@@ -737,7 +737,7 @@ class block_iomad_company_admin_external extends external_api {
                                               $company->id,
                                                $userrecord['departmentid'],
                                                $userrecord['managertype'],
-                                               null,
+                                               $userrecord['educator'],
                                                true)) {
                  $succeeded = false;
                  $errormessage = "Unable to assign user";


### PR DESCRIPTION
In the current version, we are unable to assign user(normal user) via API. This PR resolves the issue.

closes https://github.com/iomad/iomad/issues/1660


