### PR TITLE
IOMAD: Fix global variable missing in auth iomadoidc

### DIFF
--- a/auth/iomadoidc/classes/utils.php
+++ b/auth/iomadoidc/classes/utils.php
@@ -118,6 +118,9 @@ class utils {
      */
     public static function debug($message, $where = '', $debugdata = null) {
 
+        //Global $CFG missing here
+        global $CFG;
+
         // IOMAD
         require_once($CFG->dirroot . '/local/iomad/lib/company.php');
         $companyid = \iomad::get_my_companyid(\context_system::instance(), false);


### PR DESCRIPTION
Hi !

The global variable $CFG is missing in the debug function here:

auth/iomadoidc/classes/utils.php  (line 119)

Cheers !
