### PR TITLE
Fixes some users not showing as prospects

### DIFF
--- a/local/iomad_learningpath/classes/companypaths.php
+++ b/local/iomad_learningpath/classes/companypaths.php
@@ -686,7 +686,7 @@ class companypaths {
         $excludeids = $this->get_users($pathid, true);
         if (!empty($excludeids)) {
             // Add SQL to remove them from the list.
-            $excludesql = " AND u.id NOT IN (" . implode(',', array_keys($excludeids)) . ")";
+            $excludesql = " AND u.id NOT IN (" . implode(',', $excludeids) . ")";
 
         } else {
             $excludesql = "";


### PR DESCRIPTION
No need to do array_keys over an array of keys. This is causing keys to be count from 0 and not displaying users that are not in the learning path.