### PR TITLE
Issue #1916, Cannot Bulk enroll users to courses when using csv uploads.

### DIFF
--- a/blocks/iomad_company_admin/uploaduser.php
+++ b/blocks/iomad_company_admin/uploaduser.php
@@ -1054,7 +1054,7 @@ if (!empty($cancelled)) {
                     // add the user to the courses selected in the upload form.
                     $courseids = array();
                     foreach ($formdata->selectedcourses as $selectedcourse) {
-                        $courseids[] = $selectedcourse;
+                        $courseids[] = $selectedcourse->id;
                     }
                     company_user::enrol($user, $courseids, $companyid);
                 }


### PR DESCRIPTION
At some point, changes in IOMAD_400_STABLE didn't make it into 401 or 402. When uploading users via CSV, bulk enrollment into courses failed because course objects were being passed into the array of ids instead of course ids.
