### PR TITLE
Fix supervisor emails for course expiry warnings

### DIFF
--- a/local/iomad/lib/company.php
+++ b/local/iomad/lib/company.php
@@ -5448,7 +5448,7 @@ mtrace("Only the one - removing them completely");
 
         $companyinfo = self::get_company_byuserid($user->id);
         $company = new company($companyinfo->id);
-        $supervisortemplate = new EmailTemplate('completion_expiry_warn_supervisor', array('course' => $course, 'user' => $user, 'company' => $company));
+        $template = new EmailTemplate('completion_expiry_warn_supervisor', array('course' => $course, 'user' => $user, 'company' => $company));
 
         // Is this enabled for this company?
         if (!$company->email_template_is_enabled('completion_expiry_warn_supervisor', 2)) {


### PR DESCRIPTION
Noticed supervisor emails are not sending when using a custom profile field for manager email address

Appears the `$supervisortemplate` variable was renamed at some point but this one was missed

Fix error: 
`Scheduled task failed: Email reports - Course expiry warning task (local_email_reports\task\course_expiry_warning_task),Call to a member function subject() on null`

When running task: `\local_email_reports\task\course_expiry_warning_task`