### PR TITLE
Typo breaks Microsoft certificate auth

### DIFF
--- a/auth/iomadoidc/lib.php
+++ b/auth/iomadoidc/lib.php
@@ -624,7 +624,7 @@ function auth_iomadoidc_is_setup_complete() {
             }
             break;
         case AUTH_IOMADOIDC_AUTH_METHOD_CERTIFICATE:
-            if (empty($pluginconfig->$clientcert) || empty($pluginconfig->clientprivatekey)) {
+            if (empty($pluginconfig->$clientcert) || empty($pluginconfig->$clientprivatekey)) {
                 return false;
             }
             break;


### PR DESCRIPTION
Missed $ sign on variable, breaks certificate auth showing on the login screen