### PR TITLE
IOMAD: Fix course expiry warning emails never sending

### DIFF
--- a/local/email_reports/classes/task/course_expiry_warning_task.php
+++ b/local/email_reports/classes/task/course_expiry_warning_task.php
@@ -65,7 +65,7 @@ class course_expiry_warning_task extends \core\task\scheduled_task {
         // Deal with courses which have expiry warnings
         $companies = [];
         foreach ($expirycourses as $expirycourse) {
-            $targettime = $runtime - ($expirycourse->validlength * 86400) - ($expirycourse->warnexpire * 86400);
+            $targettime = $runtime - ($expirycourse->validlength * 86400) + ($expirycourse->warnexpire * 86400);
 
             // Get the companies from the list of users in the temp table.
             $companysql = "SELECT DISTINCT lit.companyid
@@ -203,7 +203,7 @@ class course_expiry_warning_task extends \core\task\scheduled_task {
         // Deal with users.
         foreach ($expirycourses as $expirycourse) {
             mtrace("Dealing with course id $expirycourse->courseid");
-            $targettime = $runtime - ($expirycourse->validlength * 86400) - ($expirycourse->warnexpire * 86400);
+            $targettime = $runtime - ($expirycourse->validlength * 86400) + ($expirycourse->warnexpire * 86400);
             $expiredsql = "SELECT lit.*, c.name AS companyname, u.firstname,u.lastname,u.username,u.email,u.lang
                            FROM {local_iomad_track} lit
                            JOIN {company} c ON (lit.companyid = c.id)


### PR DESCRIPTION
If `Days to email before training expires` is set to something other than 0, warning emails would never get sent, instead it would have the impact of making the course expire this many days more than intended.

Example with revised logic:
Course completed 2024-08-21
Training to expire in 365 days
Warning to be 30 days

Cron runs 2025-07-30
2025-07-30 - 365 days + 30 days = Target Time of 2024-08-29

Time completed is now less than target time (in the SQL) and an expiry warning will be sent

Under the old logic:
2025-07-30 - 365 days - 30 days = Target Time of 2024-06-30

Time completed is MORE than target time = warning never sent
