### PR TITLE
OIDC/OpenID Auth Bug Fixes

### DIFF
--- a/auth/iomadoidc/classes/iomadoidcclient.php
+++ b/auth/iomadoidc/classes/iomadoidcclient.php
@@ -195,7 +195,7 @@ class iomadoidcclient {
             'redirect_uri' => $this->redirecturi
         ];
 
-        if (get_config('auth_iomadoidc', 'idptype' . $postfix) != AUTH_IOMADoIDC_IDP_TYPE_MICROSOFT) {
+        if (get_config('auth_iomadoidc', 'idptype' . $postfix) != AUTH_IOMADOIDC_IDP_TYPE_MICROSOFT) {
             $params['resource'] = $this->tokenresource;
         }
 
@@ -435,6 +435,10 @@ class iomadoidcclient {
             $postfix = "";
         }
 
+        $cfg_tokenendpoint = 'tokenendpoint' . $postfix;
+        $cfg_clientid = 'clientid' . $postfix;
+        $cfg_clientprivatekey = 'clientprivatekey' . $postfix;
+        
         $jwt = new jwt();
         $authiomadoidcconfig = get_config('auth_iomadoidc');
         $opname = "clientcert" . $postfix;
@@ -443,15 +447,15 @@ class iomadoidcclient {
         $x5t = base64_encode(hex2bin($sh1hash));
         $jwt->set_header(['alg' => 'RS256', 'typ' => 'JWT', 'x5t' => $x5t]);
         $jwt->set_claims([
-            'aud' => $authiomadoidcconfig->tokenendpoint,
+            'aud' => $authiomadoidcconfig->$cfg_tokenendpoint,
             'exp' => strtotime('+10min'),
-            'iss' => $authiomadoidcconfig->clientid,
+            'iss' => $authiomadoidcconfig->$cfg_clientid,
             'jti' => bin2hex(openssl_random_pseudo_bytes(16)),
             'nbf' => time(),
-            'sub' => $authiomadoidcconfig->clientid,
+            'sub' => $authiomadoidcconfig->$cfg_clientid,
             'iat' => time(),
         ]);
 
-        return $jwt->assert_token($authiomadoidcconfig->clientprivatekey);
+        return $jwt->assert_token($authiomadoidcconfig->$cfg_clientprivatekey);
     }
 }

--- a/auth/iomadoidc/lib.php
+++ b/auth/iomadoidc/lib.php
@@ -624,7 +624,7 @@ function auth_iomadoidc_is_setup_complete() {
             }
             break;
         case AUTH_IOMADOIDC_AUTH_METHOD_CERTIFICATE:
-            if (empty($pluginconfig->$clientcert) || empty($pluginconfig->clientprivatekey)) {
+            if (empty($pluginconfig->$clientcert) || empty($pluginconfig->$clientprivatekey)) {
                 return false;
             }
             break;

--- a/auth/iomadoidc/lib.php
+++ b/auth/iomadoidc/lib.php
@@ -432,9 +432,10 @@ function auth_iomadoidc_apply_default_email_mapping() {
  * @param boolean $mapremotefields Map fields or lock only.
  * @param boolean $updateremotefields Allow remote updates
  * @param array $customfields list of custom profile fields
+ * @param string $postfix IOMAD Company ID to append to settings
  */
 function auth_iomadoidc_display_auth_lock_options($settings, $auth, $userfields, $helptext, $mapremotefields, $updateremotefields,
-    $customfields = array()) {
+    $customfields = array(), $postfix = "") {
     global $DB;
 
     // Introductory explanation and help text.
@@ -506,35 +507,35 @@ function auth_iomadoidc_display_auth_lock_options($settings, $auth, $userfields,
             // Display a message that the field can not be mapped because it's too long.
             $url = new moodle_url('/user/profile/index.php');
             $a = (object)['fieldname' => s($fieldname), 'shortname' => s($field), 'charlimit' => 67, 'link' => $url->out()];
-            $settings->add(new admin_setting_heading($auth.'/field_not_mapped_'.sha1($field), '',
+            $settings->add(new admin_setting_heading($auth.'/field_not_mapped_'.sha1($field . $postfix), '',
                 get_string('cannotmapfield', 'auth', $a)));
         } else if ($mapremotefields) {
             // We are mapping to a remote field here.
             // Mapping.
             if ($field == 'email') {
-                $settings->add(new admin_setting_configselect("auth_iomadoidc/field_map_{$field}",
+                $settings->add(new admin_setting_configselect("auth_iomadoidc/field_map_{$field}" . $postfix,
                     get_string('auth_fieldmapping', 'auth', $fieldname), '', null, $emailremotefields));
             } else {
-                $settings->add(new admin_setting_configselect("auth_iomadoidc/field_map_{$field}",
+                $settings->add(new admin_setting_configselect("auth_iomadoidc/field_map_{$field}" . $postfix,
                     get_string('auth_fieldmapping', 'auth', $fieldname), '', null, $remotefields));
             }
 
             // Update local.
-            $settings->add(new admin_setting_configselect("auth_{$auth}/field_updatelocal_{$field}",
+            $settings->add(new admin_setting_configselect("auth_{$auth}/field_updatelocal_{$field}" . $postfix,
                 get_string('auth_updatelocalfield', 'auth', $fieldname), '', 'always', $updatelocaloptions));
 
             // Update remote.
             if ($updateremotefields) {
-                $settings->add(new admin_setting_configselect("auth_{$auth}/field_updateremote_{$field}",
+                $settings->add(new admin_setting_configselect("auth_{$auth}/field_updateremote_{$field}" . $postfix,
                     get_string('auth_updateremotefield', 'auth', $fieldname), '', 0, $updateextoptions));
             }
 
             // Lock fields.
-            $settings->add(new admin_setting_configselect("auth_{$auth}/field_lock_{$field}",
+            $settings->add(new admin_setting_configselect("auth_{$auth}/field_lock_{$field}" . $postfix,
                 get_string('auth_fieldlockfield', 'auth', $fieldname), '', 'unlocked', $lockoptions));
         } else {
             // Lock fields Only.
-            $settings->add(new admin_setting_configselect("auth_{$auth}/field_lock_{$field}",
+            $settings->add(new admin_setting_configselect("auth_{$auth}/field_lock_{$field}" . $postfix,
                 get_string('auth_fieldlockfield', 'auth', $fieldname), '', 'unlocked', $lockoptions));
         }
     }

--- a/auth/iomadoidc/manageapplication.php
+++ b/auth/iomadoidc/manageapplication.php
@@ -61,8 +61,6 @@ require_admin();
 
 $iomadoidcconfig = get_config('auth_iomadoidc');
 
-$form = new application(null, ['iomadoidcconfig' => $iomadoidcconfig]);
-
 $formdata = [];
 foreach (['idptype', 'clientid', 'clientauthmethod', 'clientsecret', 'clientprivatekey', 'clientcert',
     'authendpoint', 'tokenendpoint', 'iomadoidcresource', 'iomadoidcscope'] as $field) {
@@ -71,6 +69,13 @@ foreach (['idptype', 'clientid', 'clientauthmethod', 'clientsecret', 'clientpriv
         $formdata[$field] = $iomadoidcconfig->$opname;
     }
 }
+
+// Fix missing Certificate auth method if set in database, needs to be done before form is created
+if (isset($formdata['idptype'])) {
+    $iomadoidcconfig->idptype = $formdata['idptype'];
+}
+
+$form = new application(null, ['iomadoidcconfig' => $iomadoidcconfig]);
 
 $form->set_data($formdata);
 

--- a/auth/iomadoidc/settings.php
+++ b/auth/iomadoidc/settings.php
@@ -239,7 +239,7 @@ if ($hassiteconfig) {
     // Display locking / mapping of profile fields.
     $authplugin = get_auth_plugin('iomadoidc');
     auth_iomadoidc_display_auth_lock_options($fieldmappingspage, $authplugin->authtype, $authplugin->userfields,
-        get_string('cfg_field_mapping_desc', 'auth_iomadoidc'), true, false, $authplugin->get_custom_user_profile_fields());
+        get_string('cfg_field_mapping_desc', 'auth_iomadoidc'), true, false, $authplugin->get_custom_user_profile_fields(), $postfix);
 }
 
 $settings = null;


### PR DESCRIPTION
Various bug fixes mostly to do with OIDC token generation/processing not selecting the correct IOMAD company $postfix version of each configuration variable. Notably with Certificate as the authentication mode and using the Microsoft v2 endpoint.

- Field mapping was not working (eg setting First Name and Surname on first sign in) due to the admin UI not saving the mapping fields with a company ID postfix
- The admin UI would always reset to `secret` auth even if `certificate` was selected, making it impossible to edit other config items on this page without attempting to set `secret` again