### PR TITLE
User course enrol emails not being sent when autoenrolling

### DIFF
--- a/local/iomad/lib/company.php
+++ b/local/iomad/lib/company.php
@@ -3885,6 +3885,7 @@ class company {
                     }
                 } else {
                     company_user::enrol($user, array($course->id), $this->id);
+                    EmailTemplate::send('user_added_to_course', array('course' => $course, 'user' => $user, 'company' => $this));
                 }
             }
         }

--- a/local/iomad/lib/company.php
+++ b/local/iomad/lib/company.php
@@ -5449,7 +5449,7 @@ mtrace("Only the one - removing them completely");
 
         $companyinfo = self::get_company_byuserid($user->id);
         $company = new company($companyinfo->id);
-        $supervisortemplate = new EmailTemplate('completion_expiry_warn_supervisor', array('course' => $course, 'user' => $user, 'company' => $company));
+        $template = new EmailTemplate('completion_expiry_warn_supervisor', array('course' => $course, 'user' => $user, 'company' => $company));
 
         // Is this enabled for this company?
         if (!$company->email_template_is_enabled('completion_expiry_warn_supervisor', 2)) {


### PR DESCRIPTION
Email notifications for when users are autoenrolled into courses are not being generated when user accounts are created.

Tested using LDAP user syncing, a user has no idea an account has been generated or that they have been assigned courses to complete without these notifications.

I have also included a bugfix for supervisor expiry warning emails