### PR TITLE
#2001 FIX remove non-standard SQLIFs for PostgreSQL

### DIFF
--- a/local/iomad/lib/company.php
+++ b/local/iomad/lib/company.php
@@ -314,12 +314,6 @@ class company {
     public static function get_companies_select($showsuspended=false, $useprepend = true, $showchildren = true, $sort = 'name', $search = '') {
         global $CFG, $DB, $USER;
 
-        // We use SQL IF statements here.  These could be different depending on the dbtype.
-        $SQLIF = "IF";
-        if ($CFG->dbtype == 'sqlsrv') {
-            $SQLIF = "IIF";
-        }
-
         // Is this an admin, or a normal user?
         if (iomad::has_capability('block/iomad_company_admin:company_view_all', context_system::instance())) {
             $sqlparams = [];
@@ -336,7 +330,7 @@ class company {
                 $sqlwhere .= " AND " . $DB->sql_like('name', ':search', false);
                 $sqlparams['search'] = '%' . $DB->sql_like_escape($search) . '%';
             }
-            $companies = $DB->get_records_sql_menu("SELECT id, $SQLIF (suspended=0, name, concat(name, ' (S)')) AS name FROM {company}
+            $companies = $DB->get_records_sql_menu("SELECT id, CASE WHEN suspended=0 THEN name ELSE concat(name, ' (S)') END AS name FROM {company}
                                                     WHERE 1 = 1
                                                     $sqlwhere
                                                     ORDER BY name",


### PR DESCRIPTION
I stumbled upon your project and checked its PostgreSQL support and found https://github.com/iomad/iomad/issues/2001

In this day and age there is no need to use non-standard IF(...,...) and IFF(...,...) as all Moodle supported databases properly support CASE statements nowadays. And SELECT COUNT(*) should never return NULL.

NOTE: I'm not running iomad myself so this patch is _completely_ untested. I am providing it as it's probably easy for you to just quick apply it and giving it a spin. And keep users from abandoning the best open source db.