### PR TITLE
IOMAD: Fix: Update visibility of $postfix property in auth_iomadsaml2\auth c…

### DIFF
--- a/auth/iomadsaml2/classes/auth.php
+++ b/auth/iomadsaml2/classes/auth.php
@@ -118,7 +118,7 @@ class auth extends \auth_plugin_base {
      * IOMAD
      * @var text $postfix the postfix used for configuration when we have a company selected.
      */
-    private $postfix = '';
+    protected $postfix = '';
 
     /**
      * Constructor.


### PR DESCRIPTION
…lass

- Changed the visibility of the $postfix property from private to protected in /auth/iomadsaml2/classes/auth.php to align with the requirements of the auth_plugin_base class.
- This fixes the fatal error: "Access level to auth_iomadsaml2\auth::$postfix must be protected (as in class auth_plugin_base) or weaker".

Reason:
- Ensures compatibility with the parent class and resolves the access level conflict that caused the application to fail.

Tested:
- Verified that the error is resolved, and the application works as expected.

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.md guidelines for how to contribute patches for Moodle. Thank you.

--
