### PR TITLE
Update mod_form.php - Fix query to get rooms

### DIFF
--- a/mod/trainingevent/mod_form.php
+++ b/mod/trainingevent/mod_form.php
@@ -70,7 +70,7 @@ class mod_trainingevent_mod_form extends moodleform_mod {
         }
         
         $publicchoices = array();
-        if ($rooms = $DB->get_recordset_sql('SELECT * FROM mdl_classroom WHERE ispublic = 1 AND companyid <> ?',
+        if ($rooms = $DB->get_recordset_sql('SELECT * FROM {classroom} WHERE ispublic = 1 AND companyid <> ?',
         [
             $params['companyid']
         ]


### PR DESCRIPTION
The query to get the rooms on line no. 73 was using `mdl_classroom` without the prefix.

I have updated this to use the proper prefix notation. So, this query will not break for anyone who doesn't use the default `mdl_` prefix.

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.md guidelines for how to contribute patches for Moodle. Thank you.

--
