### PR TITLE
Fix: Blanket license should not require educator flag for user allocation

### DIFF
--- a/blocks/iomad_company_admin/lib/user_selectors.php
+++ b/blocks/iomad_company_admin/lib/user_selectors.php
@@ -1280,7 +1280,8 @@ class potential_license_user_selector extends company_user_selector_base {
         $myusers = company::get_my_users($this->companyid);
 
         // are we dealing with an educator license?
-        if ($this->license->type > 1) {
+        // Types 2 and 3 are educator licenses, type 4 (blanket) is for all users
+        if ($this->license->type == 2 || $this->license->type == 3) {
             $edusql = " AND u.id IN (SELECT userid FROM {company_users} WHERE educator = 1) ";
         } else {
             $edusql = "";


### PR DESCRIPTION
## Summary
  - Fixes blanket license (type 4) incorrectly filtering for educator users only

  ## Problem
  The condition `$this->license->type > 1` was intended to filter educators for
  license types 2 (Educator) and 3 (Educator Reusable), but it also incorrectly
  includes type 4 (Blanket).

  ## Solution
  Changed condition to explicitly check for educator license types only:
  `$this->license->type == 2 || $this->license->type == 3`

  ## Test Plan
  - [ ] Create a Blanket license for a company
  - [ ] Verify regular (non-educator) users appear in the allocation list
  - [ ] Verify Educator licenses (types 2/3) still filter for educator users only

