### PR TITLE
Feature Request (OIDC): Add UserInfo Endpoint Support and Improve Username Claim Handling for Non-Microsoft IdPs (#2589)

### DIFF
--- a/auth/iomadoidc/classes/form/application.php
+++ b/auth/iomadoidc/classes/form/application.php
@@ -149,6 +149,11 @@ class application extends moodleform {
         $mform->addElement('static', 'tokenendpoint_help', '', get_string('tokenendpoint_help', 'auth_iomadoidc'));
         $mform->addRule('tokenendpoint', null, 'required', null, 'client');
 
+        // UserInfo endpoint.
+        $mform->addElement('text', 'userinfoendpoint', auth_iomadoidc_config_name_in_form('userinfoendpoint'), ['size' => 60]);
+        $mform->setType('userinfoendpoint', PARAM_URL);
+        $mform->addElement('static', 'userinfoendpoint_help', '', get_string('userinfoendpoint_help', 'auth_iomadoidc'));
+
         // "Other parameters" header.
         $mform->addElement('header', 'otherparams', get_string('settings_section_other_params', 'auth_iomadoidc'));
         $mform->setExpanded('otherparams');

--- a/auth/iomadoidc/classes/iomadoidcclient.php
+++ b/auth/iomadoidc/classes/iomadoidcclient.php
@@ -403,6 +403,39 @@ class iomadoidcclient {
     }
 
     /**
+     * Fetch user information from the UserInfo endpoint.
+     *
+     * @param string $accesstoken The access token to use for authentication.
+     * @return array|false User information from the UserInfo endpoint, or false on failure.
+     */
+    public function fetch_userinfo($accesstoken) {
+        if (empty($this->endpoints['userinfo'])) {
+            return false;
+        }
+
+        $options = [
+            'CURLOPT_HTTPHEADER' => [
+                'Authorization: Bearer ' . $accesstoken,
+            ],
+        ];
+
+        try {
+            $returned = $this->httpclient->get($this->endpoints['userinfo'], [], $options);
+            $userinfo = @json_decode($returned, true);
+
+            if (empty($userinfo) || !is_array($userinfo)) {
+                utils::debug('Invalid UserInfo response', __METHOD__, $returned);
+                return false;
+            }
+
+            return $userinfo;
+        } catch (\Exception $e) {
+            utils::debug('Error fetching UserInfo', __METHOD__, $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
      * Calculate the return the assertion used in the token request in certificate connection method.
      *
      * @return string

--- a/auth/iomadoidc/classes/loginflow/authcode.php
+++ b/auth/iomadoidc/classes/loginflow/authcode.php
@@ -339,6 +339,18 @@ class authcode extends base {
         // Decode and verify ID token.
         [$iomadoidcuniqid, $idtoken] = $this->process_idtoken($tokenparams['id_token'], $orignonce);
 
+        // Fetch additional user claims from UserInfo endpoint.
+        if (isset($tokenparams['access_token'])) {
+            try {
+                $userinfo = $client->fetch_userinfo($tokenparams['access_token']);
+                if (!empty($userinfo)) {
+                    $tokenparams['userinfo'] = $userinfo;
+                }
+            } catch (\Exception $e) {
+                utils::debug('Failed to fetch userinfo: ' . $e->getMessage(), __METHOD__);
+            }
+        }
+
         // Check restrictions.
         $passed = $this->checkrestrictions($idtoken);
         if ($passed !== true && empty($additionaldata['ignorerestrictions'])) {
@@ -375,6 +387,12 @@ class authcode extends base {
                 $upn = $idtoken->claim('upn');
                 if (empty($upn)) {
                     $upn = $idtoken->claim('unique_name');
+                }
+                if (empty($upn)) {
+                    $upn = $idtoken->claim('preferred_username');
+                }
+                if (empty($upn)) {
+                    $upn = $idtoken->claim('email');
                 }
             }
             $userrec = $DB->count_records_sql('SELECT COUNT(*)
@@ -576,6 +594,12 @@ class authcode extends base {
             if (empty($iomadoidcusername)) {
                 $iomadoidcusername = $idtoken->claim('unique_name');
             }
+            if (empty($iomadoidcusername)) {
+                $iomadoidcusername = $idtoken->claim('preferred_username');
+            }
+            if (empty($iomadoidcusername)) {
+                $iomadoidcusername = $idtoken->claim('email');
+            }
         }
         if (empty($iomadoidcusername)) {
             $iomadoidcusername = $idtoken->claim('sub');
@@ -709,6 +733,12 @@ class authcode extends base {
                 if (empty($username)) {
                     $username = $idtoken->claim('unique_name');
                 }
+                if (empty($username)) {
+                    $username = $idtoken->claim('preferred_username');
+                }
+                if (empty($username)) {
+                    $username = $idtoken->claim('email');
+                }
             }
             $originalupn = null;
 
@@ -779,8 +809,22 @@ class authcode extends base {
                 if (empty($username)) {
                     $username = $idtoken->claim('unique_name');
                 }
+                if (empty($username)) {
+                    $username = $idtoken->claim('preferred_username');
+                }
+                if (empty($username)) {
+                    $username = $idtoken->claim('email');
+                }
             }
             $originalupn = null;
+
+            if (empty($username) && isset($tokenparams['userinfo'])) {
+                if (isset($tokenparams['userinfo']['preferred_username'])) {
+                    $username = $tokenparams['userinfo']['preferred_username'];
+                } else if (isset($tokenparams['userinfo']['email'])) {
+                    $username = $tokenparams['userinfo']['email'];
+                }
+            }
 
             if (empty($username)) {
                 $username = $iomadoidcuniqid;
@@ -814,7 +858,8 @@ class authcode extends base {
                 // User does not exist. Create user if site allows, otherwise fail.
                 if (empty($CFG->authpreventaccountcreation)) {
                     if (!$CFG->allowaccountssameemail) {
-                        $userinfo = $this->get_userinfo($username);
+                        $additionalclaims = isset($tokenparams['userinfo']) ? $tokenparams['userinfo'] : [];
+                        $userinfo = $this->get_userinfo($username, $additionalclaims);
                         if ($DB->count_records('user', array('email' => $userinfo['email'], 'deleted' => 0)) > 0) {
                             throw new moodle_exception('errorauthloginfaileddupemail', 'auth_iomadoidc', null, null, '1');
                         }

--- a/auth/iomadoidc/classes/loginflow/base.php
+++ b/auth/iomadoidc/classes/loginflow/base.php
@@ -121,7 +121,7 @@ class base {
      * @param string $username username
      * @return mixed array with no magic quotes or false on error
      */
-    public function get_userinfo($username) {
+    public function get_userinfo($username, $additionalclaims = []) {
         global $DB;
 
         $tokenrec = $DB->get_record('auth_iomadoidc_token', ['username' => $username]);
@@ -190,6 +190,12 @@ class base {
                                 if (empty($upn)) {
                                     $upn = $token->claim('unique_name');
                                 }
+                                if (empty($upn)) {
+                                    $upn = $token->claim('preferred_username');
+                                }
+                                if (empty($upn)) {
+                                    $upn = $token->claim('email');
+                                }
                             }
                             if (!empty($upn)) {
                                 $userdata['userPrincipalName'] = $upn;
@@ -210,6 +216,20 @@ class base {
                             }
                         }
 
+                        if (!isset($userdata['givenName']) && !isset($userdata['surname'])) {
+                            $fullname = $token->claim('name');
+                            if (!empty($fullname)) {
+                                $nameparts = explode(' ', trim($fullname), 2);
+                                if (count($nameparts) == 2) {
+                                    $userdata['givenName'] = $nameparts[0];
+                                    $userdata['surname'] = $nameparts[1];
+                                } else if (count($nameparts) == 1) {
+                                    $userdata['givenName'] = $nameparts[0];
+                                    $userdata['surname'] = '';
+                                }
+                            }
+                        }
+
                         if (!isset($userdata['mail'])) {
                             $email = $token->claim('email');
                             if (!empty($email)) {
@@ -224,6 +244,10 @@ class base {
                             }
                         }
                     }
+                }
+
+                if (!empty($additionalclaims)) {
+                    $userdata = static::merge_userinfo_with_token_claims($userdata, $additionalclaims);
                 }
 
                 // Call the function in local_o365 to map fields.
@@ -269,6 +293,12 @@ class base {
                         if (empty($upn)) {
                             $upn = $token->claim('unique_name');
                         }
+                        if (empty($upn)) {
+                            $upn = $token->claim('preferred_username');
+                        }
+                        if (empty($upn)) {
+                            $upn = $token->claim('email');
+                        }
                     }
                     if (!empty($upn)) {
                         $userdata['userPrincipalName'] = $upn;
@@ -289,6 +319,20 @@ class base {
                     }
                 }
 
+                if (!isset($userdata['givenName']) && !isset($userdata['surname'])) {
+                    $fullname = $token->claim('name');
+                    if (!empty($fullname)) {
+                        $nameparts = explode(' ', trim($fullname), 2);
+                        if (count($nameparts) == 2) {
+                            $userdata['givenName'] = $nameparts[0];
+                            $userdata['surname'] = $nameparts[1];
+                        } else if (count($nameparts) == 1) {
+                            $userdata['givenName'] = $nameparts[0];
+                            $userdata['surname'] = '';
+                        }
+                    }
+                }
+
                 if (!isset($userdata['mail'])) {
                     $email = $token->claim('email');
                     if (!empty($email)) {
@@ -302,6 +346,10 @@ class base {
                         }
                     }
                 }
+            }
+
+            if (!empty($additionalclaims)) {
+                $userdata = static::merge_userinfo_with_token_claims($userdata, $additionalclaims);
             }
 
             $updateduser = static::apply_configured_fieldmap_from_token($userdata, $eventtype);
@@ -537,6 +585,7 @@ class base {
         $iomadoidcscopename = "iomadoidcscope" . $this->postfix;
         $authendpointname = "authendpoint" . $this->postfix;
         $tokenendpointname = "tokenendpoint" . $this->postfix;
+        $userinfoendpointname = "userinfoendpoint" . $this->postfix;
         $clientid = (isset($this->config->$clientidname)) ? $this->config->$clientidname : null;
         $clientsecret = (isset($this->config->$clientsecretname)) ? $this->config->$clientsecretname : null;
         $redirecturi = (!empty($CFG->loginhttps)) ? str_replace('http://', 'https://', $CFG->wwwroot) : $CFG->wwwroot;
@@ -547,7 +596,16 @@ class base {
         $client = new iomadoidcclient($this->httpclient);
         $client->setcreds($clientid, $clientsecret, $redirecturi, $tokenresource, $scope);
 
-        $client->setendpoints(['auth' => $this->config->$authendpointname, 'token' => $this->config->$tokenendpointname]);
+        $endpoints = [
+            'auth' => $this->config->$authendpointname,
+            'token' => $this->config->$tokenendpointname
+        ];
+
+        if (isset($this->config->$userinfoendpointname) && !empty($this->config->$userinfoendpointname)) {
+            $endpoints['userinfo'] = $this->config->$userinfoendpointname;
+        }
+
+        $client->setendpoints($endpoints);
 
         return $client;
     }
@@ -607,6 +665,12 @@ class base {
                 $tomatch = $idtoken->claim('upn');
                 if (empty($tomatch)) {
                     $tomatch = $idtoken->claim('unique_name');
+                }
+                if (empty($tomatch)) {
+                    $tomatch = $idtoken->claim('preferred_username');
+                }
+                if (empty($tomatch)) {
+                    $tomatch = $idtoken->claim('email');
                 }
             }
 
@@ -683,6 +747,12 @@ class base {
                 if (empty($iomadoidcusername)) {
                     $iomadoidcusername = $idtoken->claim('unique_name');
                 }
+                if (empty($iomadoidcusername)) {
+                    $iomadoidcusername = $idtoken->claim('preferred_username');
+                }
+                if (empty($iomadoidcusername)) {
+                    $iomadoidcusername = $idtoken->claim('email');
+                }
             }
 
             if (empty($iomadoidcusername)) {
@@ -754,5 +824,36 @@ class base {
         $tokenrec->refreshtoken = !empty($tokenparams['refresh_token']) ? $tokenparams['refresh_token'] : ''; // TBD?
         $tokenrec->idtoken = $tokenparams['id_token'];
         $DB->update_record('auth_iomadoidc_token', $tokenrec);
+    }
+
+    protected static function merge_userinfo_with_token_claims(array $userdata, array $userinfo) {
+        if (empty($userinfo)) {
+            return $userdata;
+        }
+
+        if (!isset($userdata['givenName']) && isset($userinfo['given_name'])) {
+            $userdata['givenName'] = $userinfo['given_name'];
+        }
+
+        if (!isset($userdata['surname']) && isset($userinfo['family_name'])) {
+            $userdata['surname'] = $userinfo['family_name'];
+        }
+
+        if (!isset($userdata['givenName']) && !isset($userdata['surname']) && isset($userinfo['name'])) {
+            $nameparts = explode(' ', $userinfo['name'], 2);
+            if (count($nameparts) == 2) {
+                $userdata['givenName'] = $nameparts[0];
+                $userdata['surname'] = $nameparts[1];
+            } else if (count($nameparts) == 1) {
+                $userdata['givenName'] = $nameparts[0];
+                $userdata['surname'] = '';
+            }
+        }
+
+        if (!isset($userdata['mail']) && isset($userinfo['email'])) {
+            $userdata['mail'] = $userinfo['email'];
+        }
+
+        return $userdata;
     }
 }

--- a/auth/iomadoidc/lang/en/auth_iomadoidc.php
+++ b/auth/iomadoidc/lang/en/auth_iomadoidc.php
@@ -159,6 +159,10 @@ $string['cfg_redirecturi_desc'] = 'This is the URI to register as the "Redirect 
 $string['tokenendpoint'] = 'Token Endpoint';
 $string['tokenendpoint_help'] = 'The URI of the token endpoint from your IdP to use.<br/>
 Note if the site is to be configured to allow users from other tenants to access, tenant specific token endpoint cannot be used.';
+$string['userinfoendpoint'] = 'UserInfo Endpoint';
+$string['userinfoendpoint_help'] = 'The URI of the UserInfo endpoint from your IdP to use. This endpoint is used to retrieve additional user profile information (such as given name and family name) that may not be included in the ID token.<br/>
+This is optional but recommended for IdPs that do not include complete user profile data in the ID token. For example, Okta\'s default authorization server includes only basic claims in the ID token, and the UserInfo endpoint is needed to retrieve the full user profile.<br/>
+Leave blank to rely solely on ID token claims.';
 $string['cfg_userrestrictions_key'] = 'User Restrictions';
 $string['cfg_userrestrictions_desc'] = 'Only allow users to log in that meet certain restrictions. <br /><b>How to use user restrictions: </b> <ul><li>Enter a <a href="https://en.wikipedia.org/wiki/Regular_expression">regular expression</a> pattern that matches the usernames of users you want to allow.</li><li>Enter one pattern per line</li><li>If you enter multiple patterns a user will be allowed if they match ANY of the patterns.</li><li>The character "/" should be escaped with "\".</li><li>If you don\'t enter any restrictions above, all users that can log in to the OpenID Connect IdP will be accepted by Moodle.</li><li>Any user that does not match any entered pattern(s) will be prevented from logging in using OpenID Connect.</li></ul>';
 $string['cfg_userrestrictionscasesensitive_key'] = 'User Restrictions Case Sensitive';
@@ -348,6 +352,7 @@ $string['settings_fieldmap_field_givenName'] = 'Given Name';
 $string['settings_fieldmap_field_jobTitle'] = 'Job Title';
 $string['settings_fieldmap_field_mail'] = 'Email';
 $string['settings_fieldmap_field_mobile'] = 'Mobile';
+$string['settings_fieldmap_field_name'] = 'Full Name';
 $string['settings_fieldmap_field_postalCode'] = 'Postal Code';
 $string['settings_fieldmap_field_preferredLanguage'] = 'Language';
 $string['settings_fieldmap_field_state'] = 'State';

--- a/auth/iomadoidc/lib.php
+++ b/auth/iomadoidc/lib.php
@@ -258,6 +258,7 @@ function auth_iomadoidc_get_remote_fields() {
             'displayName' => get_string('settings_fieldmap_field_displayName', 'auth_iomadoidc'),
             'givenName' => get_string('settings_fieldmap_field_givenName', 'auth_iomadoidc'),
             'surname' => get_string('settings_fieldmap_field_surname', 'auth_iomadoidc'),
+            'name' => get_string('settings_fieldmap_field_name', 'auth_iomadoidc'),
             'mail' => get_string('settings_fieldmap_field_mail', 'auth_iomadoidc'),
             'onPremisesSamAccountName' => get_string('settings_fieldmap_field_onPremisesSamAccountName', 'auth_iomadoidc'),
             'streetAddress' => get_string('settings_fieldmap_field_streetAddress', 'auth_iomadoidc'),
@@ -314,6 +315,7 @@ function auth_iomadoidc_get_remote_fields() {
             'userPrincipalName' => get_string('settings_fieldmap_field_userPrincipalName', 'auth_iomadoidc'),
             'givenName' => get_string('settings_fieldmap_field_givenName', 'auth_iomadoidc'),
             'surname' => get_string('settings_fieldmap_field_surname', 'auth_iomadoidc'),
+            'name' => get_string('settings_fieldmap_field_name', 'auth_iomadoidc'),
             'mail' => get_string('settings_fieldmap_field_mail', 'auth_iomadoidc'),
         ];
     }

--- a/auth/iomadoidc/manageapplication.php
+++ b/auth/iomadoidc/manageapplication.php
@@ -73,7 +73,7 @@ $form = new application(null, ['iomadoidcconfig' => $iomadoidcconfig]);
 $formdata = ['companyonly' => $companyonly];
 foreach (['idptype', 'clientid', 'clientauthmethod', 'clientsecret', 'clientprivatekey', 'clientcert',
     'clientcertsource', 'clientprivatekeyfile', 'clientcertfile', 'clientcertpassphrase',
-    'authendpoint', 'tokenendpoint', 'iomadoidcresource', 'iomadoidcscope', 'secretexpiryrecipients'] as $field) {
+    'authendpoint', 'tokenendpoint', 'userinfoendpoint', 'iomadoidcresource', 'iomadoidcscope', 'secretexpiryrecipients'] as $field) {
     $fieldname = $field . $postfix;
     if (isset($iomadoidcconfig->$fieldname)) {
         $formdata[$field] = $iomadoidcconfig->$fieldname;
@@ -92,7 +92,7 @@ if ($form->is_cancelled()) {
 
     // Prepare config settings to save.
     $configstosave = ['idptype', 'clientid', 'clientauthmethod', 'authendpoint', 'tokenendpoint',
-        'iomadoidcresource', 'iomadoidcscope'];
+        'userinfoendpoint', 'iomadoidcresource', 'iomadoidcscope'];
 
     // Depending on the value of clientauthmethod, save clientsecret or (clientprivatekey and clientcert).
     switch ($fromform->clientauthmethod) {


### PR DESCRIPTION
This PR implements the improvements requested in #2589.

It adds support for retrieving claims from the OIDC UserInfo endpoint and improves the logic for resolving the username claim, especially for non‑Microsoft identity providers.
This increases compatibility with standard‑compliant OIDC IdPs and ensures consistent username generation.

It was tested with Okta and for backward compatibility with Microsoft Entra ID.

Fixes #2589