### PR TITLE
local_email: email template language dropdown ignores selection (#2595)

### DIFF
--- a/local/email/template_edit_form.php
+++ b/local/email/template_edit_form.php
@@ -95,16 +95,16 @@ if (empty($templatesetid)) {
                                                 WHERE et.id = :id
                                                 AND ets.lang = :lang",
                                                ['id' => $templateid,
-                                               'lang' => $lang])) {
+                                                'lang' => $lang])) {
         throw new \moodle_exception('templatenotfound', 'local_email', new moodle_url('/local/email/template_list.php'));
     }
 }
 
 if (empty($templaterecord->subject)) {
-    $templaterecord->subject = get_string($templatename . '_subject', 'local_email', $lang);
+    $templaterecord->subject = get_string_manager()->get_string($templatename . '_subject', 'local_email', null, $lang);
 }
 if (empty($templaterecord->body)) {
-    $templaterecord->body = get_string($templatename . '_body', 'local_email', $lang);
+    $templaterecord->body = get_string_manager()->get_string($templatename . '_body', 'local_email', null, $lang);
 }
 
 // Correct the navbar.


### PR DESCRIPTION
Issue: Unedited email templates always displayed in session language instead of selected dropdown language.

Cause: Incorrect use of get_string() - language parameter was passed as 3rd argument (string substitution) instead of 4th argument (language selector).

Fix: Changed to get_string_manager()->get_string($key, $component, null, $lang)