### PR TITLE
4.5.6: Password Change Error for External Auth Users After Password Reset (#2598)

### DIFF
--- a/auth/iomadsaml2/classes/auth.php
+++ b/auth/iomadsaml2/classes/auth.php
@@ -811,6 +811,10 @@ class auth extends \auth_plugin_base {
                 profile_save_data($user);
                 // Make sure all user data is fetched.
                 $user = \core_user::get_user($user->id);
+
+                // For external authentication plugins, properly initialize the password field
+                // to AUTH_PASSWORD_NOT_CACHED to prevent password policy checks from failing
+                update_internal_user_password($user, '');
             } else {
                 // Moodle user does not exist and settings prevent creating new accounts.
                 $event = \core\event\user_login_failed::create(['other' => ['username' => $uid,

--- a/local/iomad/lib/user.php
+++ b/local/iomad/lib/user.php
@@ -169,6 +169,13 @@ class company_user {
             $id = user_create_user($user);
             $user->id = $id;
 
+            // For external authentication plugins, properly initialize the password field
+            // to AUTH_PASSWORD_NOT_CACHED to prevent password policy checks from failing
+            if (!$authplugin->is_internal()) {
+                $fulluser = get_complete_user_data('id', $user->id);
+                update_internal_user_password($fulluser, '');
+            }
+
             // Passwords will be created and sent out on cron.
             if ($createpassword) {
                 set_user_preference('create_password', 1, $user->id);


### PR DESCRIPTION
Fixes #2598 password initialization for external auth users (OIDC/SAML2) created via sync or direct user creation. Adds `update_internal_user_password()` call after user creation to properly set password field to `'not cached'`, preventing `nopasswordchangeforced` errors when password policy checking is enabled.
