### PR TITLE
4.5.8: Certificate Download Fails with ERR_INVALID_RESPONSE in 'Show all users' view

### DIFF
--- a/local/iomad_track/lang/en/local_iomad_track.php
+++ b/local/iomad_track/lang/en/local_iomad_track.php
@@ -59,3 +59,5 @@ $string['importcompletionsfromfile'] = 'Import completion information from file'
 $string['courseswithoutcompletionenabledcouunt'] = 'Number of courses which do not have completion enabled = {$a}';
 $string['courseswithoutcompletioncriteriacouunt'] ='Number of courses which have no completion criteria = {$a}';
 $string['checkcoursestatusmoodle'] = 'Check course settings for import';
+$string['nocertificatesfound'] = 'No certificates found to download';
+$string['erroropeningzip'] = 'Error creating ZIP file: {$a}';

--- a/local/iomad_track/lib.php
+++ b/local/iomad_track/lib.php
@@ -121,7 +121,7 @@ function local_iomad_track_download_certs($companyid = 0, $courses = [], $users 
 
     // Deal with the courses.
     if (empty($courses)) {
-        $allcourses = array_keys($company->get_menu_courses(true, false, false, false)); 
+        $allcourses = array_keys($company->get_menu_courses(true, false, false, false));
     } else {
         $allcourses = $courses;
     }
@@ -132,16 +132,25 @@ function local_iomad_track_download_certs($companyid = 0, $courses = [], $users 
         $sqlselect .= " AND userid IN (" . implode(',', $users) . ")";
     }
 
+    // Ensure the temp directory exists
+    $tempdir = $CFG->dataroot . '/temp/filestorage';
+    if (!file_exists($tempdir)) {
+        mkdir($tempdir, 0777, true);
+    }
+
     // create the zip file
     $zipfile = new ZipArchive();
-    $tempfilename = $CFG->dataroot . '/temp/filestorage/' . time();
+    $tempfilename = $tempdir . '/' . time() . '_' . random_string(10);
     $realfilename = "certificates.zip";
-    if ($zipfile->open($tempfilename, ZipArchive::CREATE) === TRUE) {
+    $zipresult = $zipfile->open($tempfilename, ZipArchive::CREATE);
+
+    if ($zipresult === TRUE) {
+        $filesadded = 0;
         foreach ($allcourses as $course) {
             $comprecords = $DB->get_records_select('local_iomad_track',
                                                     $sqlselect,
                                                    ['courseid' => $course,
-                                                    'companyid' => $company->id]); 
+                                                    'companyid' => $company->id]);
             if (count($comprecords) > 0) {
                 // For all of the track saved files
                 foreach ($comprecords as $comprecord) {
@@ -155,11 +164,24 @@ function local_iomad_track_download_certs($companyid = 0, $courses = [], $users 
                                                            'filearea' => 'issue',
                                                            'itemid' => $comprecord->id])) {
                         if ($userrec = $DB->get_record('user', ['id' => $comprecord->userid])) {
-                            $savefilename = $comprecord->coursename . "/" . $userrec->firstname . "_" . $userrec->lastname . "_" . $userrec->id . "/" . $comprecord->id . "_" . $filerec->filename;
+                            $cleancoursename = clean_filename(format_string($comprecord->coursename));
+                            $cleanfirstname = clean_filename($userrec->firstname);
+                            $cleanlastname = clean_filename($userrec->lastname);
+                            $savefilename = $cleancoursename . "/" .
+                                          $cleanfirstname . "_" .
+                                          $cleanlastname . "_" .
+                                          $userrec->id . "/" .
+                                          $comprecord->id . "_" .
+                                          $filerec->filename;
                             $first = substr($filerec->contenthash, 0, 2);
                             $second = substr($filerec->contenthash, 2, 2);
                             $filepath = $CFG->dataroot . "/filedir/$first/$second/" . $filerec->contenthash;
-                            $zipfile->addFile($filepath, $savefilename);
+
+                            if (file_exists($filepath)) {
+                                if ($zipfile->addFile($filepath, $savefilename)) {
+                                    $filesadded++;
+                                }
+                            }
                         }
                     }
                 }
@@ -167,20 +189,30 @@ function local_iomad_track_download_certs($companyid = 0, $courses = [], $users 
         }
         $zipfile->close();
 
-        // Send the headers to force download the zip file
-        header("Content-type: application/zip");
-        header("Content-Disposition: attachment; filename=$realfilename");
-        header("Content-length: " . filesize($tempfilename));
-        header("Pragma: no-cache");
-        header("Expires: 0");
-        ob_clean();
-        flush();
-        $handle = fopen($tempfilename, "rb");
-        while (!feof($handle)){
-            echo fread($handle, 8192);
+        if ($filesadded > 0 && file_exists($tempfilename) && filesize($tempfilename) > 0) {
+            // Send the headers to force download the zip file
+            header("Content-type: application/zip");
+            header("Content-Disposition: attachment; filename=$realfilename");
+            header("Content-length: " . filesize($tempfilename));
+            header("Pragma: no-cache");
+            header("Expires: 0");
+            ob_clean();
+            flush();
+            $handle = fopen($tempfilename, "rb");
+            while (!feof($handle)){
+                echo fread($handle, 8192);
+            }
+            fclose($handle);
+            unlink($tempfilename);
+            exit;
+        } else {
+            if (file_exists($tempfilename)) {
+                unlink($tempfilename);
+            }
+            throw new moodle_exception('nocertificatesfound', 'local_iomad_track');
         }
-        fclose($handle);
-        unlink($tempfilename);
-        exit;
+    } else {
+        throw new moodle_exception('erroropeningzip', 'local_iomad_track', '',
+            'ZipArchive error code: ' . $zipresult);
     }
 }

--- a/local/report_completion/index.php
+++ b/local/report_completion/index.php
@@ -232,10 +232,8 @@ if (!empty($courseid)) {
     $buttons .= $OUTPUT->single_button($buttonlink, $buttoncaption, 'get');
     if (iomad::has_capability('block/iomad_company_admin:downloadcertificates', $companycontext)) {
         $buttoncaption = get_string('downloadcertificates', 'block_iomad_company_admin');
-        $buttonlink = new moodle_url($CFG->wwwroot . "/local/report_completion/index.php", ['certcourses' => $courseid,
-                                                                                            'certusers' => 0,
-                                                                                            'action' => 'downloadcerts',
-                                                                                            'sesskey' => sesskey()]);
+        $certcourseid = ($courseid == 1) ? 0 : $courseid;
+        $buttonlink = new moodle_url($CFG->wwwroot . "/local/report_completion/index.php", ['certcourses' => $certcourseid, 'certusers' => 0, 'action' => 'downloadcerts', 'sesskey' => sesskey()]);
         $buttons .= $OUTPUT->single_button($buttonlink, $buttoncaption, 'get');
     }
 
@@ -1195,7 +1193,7 @@ if (empty($courseid)) {
     $percentageuserslink = new moodle_url($baseurl, $params);
     $percentageselect = new single_select($percentageuserslink, 'showpercentage', $showpercentageoptions, $showpercentage);
 
-    $buttons = $output->render($percentageselect) . "&nbsp" .$buttons;;
+    $buttons = $output->render($percentageselect) . "&nbsp" .$buttons;
 
     $total = $DB->count_records_sql(
         "SELECT count(DISTINCT lit.id)


### PR DESCRIPTION
Fixes #2608 certificate download failures caused by incorrect course ID parameter in "all users" view and missing filename sanitization for multilanguage characters. Adds proper error handling for ZIP operations to prevent ERR_INVALID_RESPONSE errors