### PR TITLE
4.5.11 Fix: Company Manager Access Issues in Manage companies

### DIFF
--- a/blocks/iomad_company_admin/editcompanies.php
+++ b/blocks/iomad_company_admin/editcompanies.php
@@ -381,20 +381,36 @@ if (!empty($params['showchild']) && !empty($params['name'])) {
 // Sort out the resulting list so we only have the distinct values.
 $companyrecords = array_unique($companyrecords);
 
+// Default to an impossible condition so no companies are shown if no valid records exist.
 $companylist = " 1 = 2 ";
 $companyparams = [];
 if (!empty($companyrecords)) {
+    // Build SQL IN clause for all matched company records from the search.
     [$insql, $companyparams] = $DB->get_in_or_equal($companyrecords,
                                                     SQL_PARAMS_NAMED,
                                                     'cids');
     $companylist = "id {$insql} ";
+    // For company managers (users without 'company_add' capability), restrict the visible companies
+    // to only those they have access to (their own company and child companies).
     if (!iomad::has_capability('block/iomad_company_admin:company_add', $context)) {
+        // Get the list of companies this user is allowed to manage.
         $mycompanylist = company::get_companies_select(true);
-        [$insql, $inparams] = $DB->get_in_or_equal($companyrecords,
-                                                   SQL_PARAMS_NAMED,
-                                                   'mycids');
-        $companylist .= "AND id {$insql}";
-        $companyparams = $companyparams + $inparams;
+        // Filter the search results to only include companies the manager has access to.
+        // This ensures managers can only see their company and child companies, not all companies.
+        $filteredcompanies = array_intersect($companyrecords, array_keys($mycompanylist));
+        if (!empty($filteredcompanies)) {
+            // Build SQL condition with the filtered company IDs accessible to this manager.
+            [$insql, $inparams] = $DB->get_in_or_equal($filteredcompanies,
+                                                       SQL_PARAMS_NAMED,
+                                                       'mycids');
+            $companylist = "id {$insql}";
+            $companyparams = $inparams;
+        } else {
+            // If no companies match both the search criteria and the manager's access rights,
+            // set an impossible condition (1 = 2) to return no results.
+            $companylist = " 1 = 2 ";
+            $companyparams = [];
+        }
     }
 }
 
@@ -460,7 +476,12 @@ if ($companies) {
         $linkparams['sesskey'] = sesskey();
         $companycontext = \core\context\company::instance($company->id);
         $strmanage = get_string('managecompany', 'block_iomad_company_admin');
-        [$pinsql, $pinparams] = $DB->get_in_or_equal($companies,
+        // Extract company IDs from the $companies array for use in SQL query.
+        // $companies is an associative array with company IDs as keys and company objects as values.
+        // We need just the IDs (scalar values) for the database query, not the full objects,
+        // as passing objects to get_in_or_equal() causes a "coding error" exception.
+        $companyids = array_keys($companies);
+        [$pinsql, $pinparams] = $DB->get_in_or_equal($companyids,
                                                      SQL_PARAMS_NAMED,
                                                      'pcids');
         $pinparams['companyid'] = $company->id;


### PR DESCRIPTION
Fixes https://github.com/iomad/iomad/issues/2698: Company managers with the need to manage child companies encounter a critical coding error when accessing "Manage companies" functionality, while system admins can access it without issues.
