### PR TITLE
4.5.11 Fix: TypeError on Microlearning Thread Update

### DIFF
--- a/blocks/iomad_microlearning/classes/microlearning.php
+++ b/blocks/iomad_microlearning/classes/microlearning.php
@@ -31,6 +31,7 @@ use block_iomad_microlearning\event\{
     nugget_moved,
     thread_deleted,
     thread_created,
+    thread_updated,
     thread_schedule_updated,
 };
 use context_system;


### PR DESCRIPTION
Fixes https://github.com/iomad/iomad/issues/2702: Editing a microlearning thread throws a TypeError due to type mismatch in the event handler.