### PR TITLE
4.5.11 Fix: TypeError during user signup

### DIFF
--- a/local/iomad_signup/lib.php
+++ b/local/iomad_signup/lib.php
@@ -94,7 +94,7 @@ function local_iomad_signup_user_created($user) {
 
         // Check if we have a company id from the URL or SESSION.
         $companyid = iomad::get_my_companyid($context, false);
-        if (!empty($companyid)) {
+        if (!empty($companyid) && $companyid > 0) {
             $company = new company($companyid);
             $found = true;
         }

--- a/login/signup.php
+++ b/login/signup.php
@@ -173,7 +173,7 @@ if ($mform_signup->is_cancelled()) {
     if (empty($SESSION->company) && !empty($CFG->local_iomad_signup_company)) {
         if ($defaultcompany = $DB->get_record('company', array('id' => $CFG->local_iomad_signup_company))) {
             $SESSION->company = $defaultcompany;
-            $SESSION->currenteditingcompany = $defaultcompany;
+            $SESSION->currenteditingcompany = $defaultcompany->id;
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/iomad/iomad/issues/2704: New account registration fails with TypeErrors when a default signup company is configured.
