### PR TITLE
4.5.11 Fix: Microlearning Cron Job Fails Due to Missing Namespace Imp…

### DIFF
--- a/blocks/iomad_microlearning/classes/microlearning.php
+++ b/blocks/iomad_microlearning/classes/microlearning.php
@@ -33,8 +33,11 @@ use block_iomad_microlearning\event\{
     thread_created,
     thread_schedule_updated,
 };
+use company;			
 use context_system;
+use EmailTemplate;				  
 use html_writer;
+use moodle_url;
 
 /**
  * IOMAD microlearning block class definition


### PR DESCRIPTION
Fixes https://github.com/iomad/iomad/issues/2706: The IOMAD microlearning cron task fails when attempting to send invitation and reminder emails with error.
