### PR TITLE
Fix Timezone Handling Bug in IOMAD Enrollment & Microlearning

### DIFF
--- a/blocks/iomad_company_admin/classes/forms/company_course_users_form.php
+++ b/blocks/iomad_company_admin/classes/forms/company_course_users_form.php
@@ -348,15 +348,9 @@ class company_course_users_form extends moodleform {
         if ($add || $addall) {
             if (!empty($userstoassign)) {
 
-                // Set the due timestamp.
                 $duedate = 0;
-                $due = optional_param_array('due', [], PARAM_INT);
-                if (!empty($due)) {
-                    $duedate = strtotime($due['year'] . '-' .
-                        $due['month'] . '-' .
-                        $due['day'] . ' ' .
-                        $due['hour'] . ':' .
-                        $due['minute']);
+                if (!empty($data) && !empty($data->due)) {
+                    $duedate = $data->due;
                 }
 
                 // Are we handling a lot of users/courses?

--- a/blocks/iomad_company_admin/classes/forms/company_users_course_form.php
+++ b/blocks/iomad_company_admin/classes/forms/company_users_course_form.php
@@ -253,6 +253,7 @@ class company_users_course_form extends moodleform {
     public function process() {
 
         $this->create_course_selectors();
+        $data = $this->get_data();
 
         // Process incoming enrolments.
         if (optional_param('add', false, PARAM_BOOL) && confirm_sesskey()) {
@@ -263,16 +264,9 @@ class company_users_course_form extends moodleform {
                     $allow = true;
 
                     if ($allow) {
-                        $due = optional_param_array('due', [], PARAM_INT);
-                        if (!empty($due)) {
-                            $duedate = strtotime(
-                                $due['year'] . '-' .
-                                $due['month'] . '-' .
-                                $due['day'] . ' ' .
-                                $due['hour'] . ':' .
-                                $due['minute']);
-                        } else {
-                            $duedate = 0;
+                        $duedate = 0;
+                        if (!empty($data) && !empty($data->due)) {
+                            $duedate = $data->due;
                         }
                         company_user::enrol($this->user, [$addcourse->id], $this->selectedcompany, false, false, $duedate);
                         EmailTemplate::send(

--- a/blocks/iomad_microlearning/classes/microlearning.php
+++ b/blocks/iomad_microlearning/classes/microlearning.php
@@ -756,11 +756,13 @@ class microlearning {
         // Do we have a schedule type?
         if (!empty($scheduletype)) {
             if ($scheduletype == 1) {
-                // We want midnight from this morning.
-                $starttime = strtotime('today midnight');
+                $date = new \DateTime("today midnight", \core_date::get_user_timezone_object($user));
+                $starttime = $date->getTimestamp();
             } else {
-                // We want midnight for the morning of the day of the next scheduled time.
-                $starttime = strtotime('midnight', self::get_next_scheduled($threadid));
+                $nextscheduled = self::get_next_scheduled($threadid);
+                $date = new \DateTime("@" . $nextscheduled, \core_date::get_user_timezone_object($user));
+                $date->setTime(0, 0, 0);
+                $starttime = $date->getTimestamp();
             }
         }
 
@@ -769,8 +771,8 @@ class microlearning {
         if (empty($threadinfo->halt_until_fulfilled)) {
             $scheduleinfo = self::get_schedules($threadinfo, $nuggets, $starttime);
         } else {
-            // We want midnight last night.
-            $starttime = time() - (time() % 86400);
+            $date = new \DateTime("today midnight", \core_date::get_user_timezone_object($user));
+            $starttime = $date->getTimestamp();
             $scheduleinfo = self::get_schedules($threadinfo, $nuggets, $starttime);
         }
 


### PR DESCRIPTION
Incorrect timestamp storage when users operate in timezones different from the server timezone. Forms used `strtotime()` which always uses server timezone instead of user timezone.
