### PR TITLE
Fix: Company Manager Loses Capabilities After Editing Child Company

### DIFF
--- a/blocks/iomad_company_admin/company_edit_form.php
+++ b/blocks/iomad_company_admin/company_edit_form.php
@@ -613,8 +613,8 @@ if ($mform->is_cancelled()) {
             $DB->insert_record('company_pages', ['companyid' => $companyid, 'pageid' => $data->dashboard, 'type' => 'dashboard']);
         }
 
-        // Is the current user in the company?
-        if (company_user::is_company_user()) {
+        // Only reload if the current user is editing their own company, not a child company they manage.
+        if (company_user::is_company_user() && isset($USER->company->id) && $USER->company->id == $companyid) {
             company_user::reload_company();
         }
     }


### PR DESCRIPTION
Fixes #2727: When a parent company manager edits a child company, they lose administrative capabilities after the form submission completes. The manager must log out and log back in to restore their permissions.