### PR TITLE
Fix: API call to block_iomad_company_admin_enrol_users throws dml_rea…

### DIFF
--- a/blocks/iomad_company_admin/externallib.php
+++ b/blocks/iomad_company_admin/externallib.php
@@ -2596,7 +2596,7 @@ It could very slow or timeout. The function is designed to search some specific 
                 $inparams['userid'] = $enrolment['userid'];
                 if (!$usercompanies = $DB->get_records_sql(
                     "SELECT companyid
-                     FROM {company_user}
+                     FROM {company_users}
                      WHERE userid = :userid
                      AND companyid {$insql}",
                     $inparams)) {


### PR DESCRIPTION
Fixes #2773 : Calling block_iomad_company_admin_enrol_users returns a dml_read_exception ("Error reading from database") when the target course is assigned to more than one company.
