### PR TITLE
Exception when downloading an iomadcertificate PDF from the report

### DIFF
--- a/mod/iomadcertificate/lib.php
+++ b/mod/iomadcertificate/lib.php
@@ -314,7 +314,7 @@ function iomadcertificate_pluginfile($course, $cm, $context, $filearea, $args, $
         $fullpath = "/{$context->id}/mod_iomadcertificate/issue/$certrecord->id/$relativepath";
 
         $fs = get_file_storage();
-        if (!$file = $fs->get_file_by_hash(sha1($fullpath)) || $file->is_directory()) {
+        if ((!$file = $fs->get_file_by_hash(sha1($fullpath))) || $file->is_directory()) {
             return false;
         }
         send_stored_file($file, 0, 0, true); // Download MUST be forced - security!


### PR DESCRIPTION
'mod/iomadcertificate/report.php?id=xxxx' - exception: Call to a member function is_external_file() on true​

IOMAD 405, 'mod/iomadcertificate/lib.php', line 317:

```
if (!$file = $fs->get_file($context->id, 'block_iomad_html', 'content', 0, $filepath, $filename) ||
                  $file->is_directory())
```

'||' has a higher precedence than '='. Need parenthesis:

`if (!($file = $fs->get_file_by_hash(sha1($fullpath))) || ...`

A similar problem can be found in 'blocks/iomad_html/lib.php:76'

